### PR TITLE
Update rest-client to fix vulns: CVE-2015-1820, OSVDB-117461

### DIFF
--- a/url_resolver.gemspec
+++ b/url_resolver.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.homepage    =
     'http://www.github.com/amirmanji/url_resolver'
   s.license       = 'MIT'
-  s.add_runtime_dependency "rest-client", [ "1.6.7" ]
+  s.add_runtime_dependency "rest-client", [ "1.8.0" ]
   s.add_development_dependency "rspec", [ "2.14.7" ]
 end


### PR DESCRIPTION
Fix for `rest-client` CVEs:
```
Name: rest-client
Version: 1.6.7
Advisory: CVE-2015-1820
Criticality: Unknown
URL: https://github.com/rest-client/rest-client/issues/369
Title: rubygem-rest-client: session fixation vulnerability via Set-Cookie headers in 30x redirection responses
Solution: upgrade to >= 1.8.0

Name: rest-client
Version: 1.6.7
Advisory: OSVDB-117461
Criticality: Unknown
URL: http://www.osvdb.org/show/osvdb/117461
Title: Rest-Client Gem for Ruby logs password information in plaintext
Solution: upgrade to >= 1.7.3
```