### PR TITLE
Gemfile and rspec fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,31 @@
+PATH
+  remote: .
+  specs:
+    url_resolver (0.1.10)
+      rest-client (= 1.6.7)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    mime-types (2.6.1)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec (= 2.14.1)
+  url_resolver!
+
+BUNDLED WITH
+   1.10.2

--- a/url_resolver.gemspec
+++ b/url_resolver.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
     'http://www.github.com/amirmanji/url_resolver'
   s.license       = 'MIT'
   s.add_runtime_dependency "rest-client", [ "1.6.7" ]
-  s.add_development_dependency "rspec", [ "2.14.7" ]
+  s.add_development_dependency "rspec", [ "2.14.1" ]
 end


### PR DESCRIPTION
When trying to run the tests there were no `Gemfile`, which made it difficult to setup. Also the specified `rspec` version (`2.14.7`) didn't exist @ rubygems.org, so I changed it to the latest patch for the `2.14.x` minor release (see https://rubygems.org/gems/rspec/versions).