### PR TITLE
make errors to ignore more configurable

### DIFF
--- a/lib/url_resolver.rb
+++ b/lib/url_resolver.rb
@@ -1,3 +1,5 @@
+require 'rest-client'
+
 require_relative 'url_resolver/cache.rb'
 require_relative 'url_resolver/cache_implementations.rb'
 require_relative 'url_resolver/configuration.rb'

--- a/lib/url_resolver/configuration.rb
+++ b/lib/url_resolver/configuration.rb
@@ -1,13 +1,31 @@
 module UrlResolver
   class Configuration
-    attr_accessor :cache_failures, :user_agent
+    attr_accessor :cache_failures, :user_agent, :errors_to_ignore
     attr_reader :cache, :url_cache
+
+    DEFAULT_ERRORS_TO_IGNORE = [SocketError,
+      Errno::ETIMEDOUT,
+      Errno::ECONNREFUSED,
+      Errno::ECONNRESET,
+      RestClient::InternalServerError,
+      RestClient::ServiceUnavailable,
+      RestClient::BadRequest,
+      RestClient::GatewayTimeout,
+      RestClient::RequestTimeout,
+      RestClient::ResourceNotFound,
+      RestClient::BadGateway,
+      RestClient::MethodNotAllowed,
+      RestClient::Unauthorized,
+      RestClient::Forbidden,
+      RestClient::NotAcceptable,
+      URI::InvalidURIError]
 
     def initialize
       @cache_failures = true
       @cache = nil
       @url_cache = Cache.new(@cache)
       @user_agent = 'Ruby'
+      @errors_to_ignore = DEFAULT_ERRORS_TO_IGNORE
     end
     
     def cache=(cache)

--- a/lib/url_resolver/resolver.rb
+++ b/lib/url_resolver/resolver.rb
@@ -1,5 +1,3 @@
-require 'rest-client'
-
 module UrlResolver
   class Resolver
     def cache
@@ -19,23 +17,8 @@ module UrlResolver
       response.args[:url].tap do |final_url|
         cache.set_url(url_to_check, final_url)
       end
-    rescue SocketError,
-      Errno::ETIMEDOUT,
-      Errno::ECONNREFUSED,
-      Errno::ECONNRESET,
-      RestClient::InternalServerError,
-      RestClient::ServiceUnavailable,
-      RestClient::BadRequest,
-      RestClient::GatewayTimeout,
-      RestClient::RequestTimeout,
-      RestClient::ResourceNotFound,
-      RestClient::BadGateway,
-      RestClient::MethodNotAllowed,
-      RestClient::Unauthorized,
-      RestClient::Forbidden,
-      RestClient::NotAcceptable,
-      URI::InvalidURIError => e
-      
+    rescue *UrlResolver.configuration.errors_to_ignore => e
+
       if e.message == 'getaddrinfo: nodename nor servname provided, or not known'
         response = RestClient.head(url_to_check) { |response, request, result, &block| response }
         url = response.headers[:location] if response.code == 302 && response.headers[:location]


### PR DESCRIPTION
Allows things like:

```ruby
UrlResolver.configure do |config|
  config.errors_to_ignore << WhateverMyErrorIs::HeyItsMyError
end
```