### PR TITLE
Add option to support timeouts passed to RestClient

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,48 @@
+PATH
+  remote: .
+  specs:
+    url_resolver (0.2.2)
+      rest-client (~> 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    domain_name (0.5.20170404)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    netrc (0.11.0)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec
+  url_resolver!
+
+BUNDLED WITH
+   1.15.0

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ UrlResolver.configure do |config|
   config.cache_failures = true # default: true
   config.user_agent = 'Custom User-Agent' # default: 'Ruby'
   config.errors_to_ignore << MyModule::MyError
+  config.timeout = 15
 end
 ```
 
@@ -44,9 +45,34 @@ UrlResolver.configuration.cache = Redis.new
 UrlResolver.configuration.cache_failures = true
 UrlResolver.configuration.user_agent = 'Custom User-Agent'
 UrlResolver.configuration.errors_to_ignore << MyModule::MyError
+UrlResolver.configuration.timeout = 15
+```
+
+If you want to specify different options on a per-call basis (or you
+prefer to not leverage the global configuration from above), you can
+pass an optional hash to the `#resolve` method
+
+```ruby
+options = { :user_agent => 'Some Other User-Agent', :timeout => 60 }
+UrlResolver.resolve('http://analytics.google.com', options)
+# => "http://www.google.com/analytics/"
+```
+
+These options are passed to `RestClient`, so you can send any options
+that `RestClient` acceptsm, such as `:max_redirects`
+
+
+```ruby
+options = { :max_redirects => 20 }
+UrlResolver.resolve('http://analytics.google.com', options)
 ```
 
 ### Changelog
+
+##### 0.2.1
++ Added timeout configuration option
++ Can pass a hash of options into the `#resolve` method to specify
+configuration parameters on a per-call basis
 
 ##### 0.1.1
 + Handle redirects that resolve to nonstandard protocols

--- a/lib/url_resolver.rb
+++ b/lib/url_resolver.rb
@@ -7,8 +7,8 @@ require_relative 'url_resolver/errors.rb'
 require_relative 'url_resolver/resolver.rb'
 
 module UrlResolver
-  def self.resolve(url)
+  def self.resolve(url, options={})
     @@resolver ||= UrlResolver::Resolver.new
-    @@resolver.resolve(url)
+    @@resolver.resolve(url, options)
   end
 end

--- a/lib/url_resolver/configuration.rb
+++ b/lib/url_resolver/configuration.rb
@@ -1,6 +1,6 @@
 module UrlResolver
   class Configuration
-    attr_accessor :cache_failures, :user_agent, :errors_to_ignore
+    attr_accessor :cache_failures, :user_agent, :timeout, :errors_to_ignore
     attr_reader :cache, :url_cache
 
     DEFAULT_ERRORS_TO_IGNORE = [SocketError,
@@ -25,6 +25,7 @@ module UrlResolver
       @cache = nil
       @url_cache = Cache.new(@cache)
       @user_agent = 'Ruby'
+      @timeout = 60
       @errors_to_ignore = DEFAULT_ERRORS_TO_IGNORE
     end
     

--- a/lib/url_resolver/resolver.rb
+++ b/lib/url_resolver/resolver.rb
@@ -21,7 +21,7 @@ module UrlResolver
       options = default_options.merge(options)
 
       response = RestClient.head(url_to_check, options)
-      response.args[:url].tap do |final_url|
+      response.request.url.tap do |final_url|
         cache.set_url(url_to_check, final_url)
       end
     rescue *UrlResolver.configuration.errors_to_ignore => e

--- a/lib/url_resolver/resolver.rb
+++ b/lib/url_resolver/resolver.rb
@@ -9,7 +9,7 @@ module UrlResolver
     end
 
     def timeout
-      UriResolver.configuration.timeout
+      UrlResolver.configuration.timeout
     end
 
     def resolve(url, options={})

--- a/lib/url_resolver/resolver.rb
+++ b/lib/url_resolver/resolver.rb
@@ -8,12 +8,19 @@ module UrlResolver
       UrlResolver.configuration.user_agent
     end
 
-    def resolve(url)
+    def timeout
+      UriResolver.configuration.timeout
+    end
+
+    def resolve(url, options={})
       url_to_check = URI.escape(url)
       cached_url = cache.get_url(url_to_check)
       return cached_url if cached_url
-      
-      response = RestClient.head(url_to_check, user_agent: user_agent)
+
+      default_options = { :user_agent => user_agent, :timeout => timeout }
+      options = default_options.merge(options)
+
+      response = RestClient.head(url_to_check, options)
       response.args[:url].tap do |final_url|
         cache.set_url(url_to_check, final_url)
       end
@@ -23,7 +30,7 @@ module UrlResolver
         response = RestClient.head(url_to_check) { |response, request, result, &block| response }
         url = response.headers[:location] if response.code == 302 && response.headers[:location]
       end
-  
+
       cache.set_url(url_to_check, url) if UrlResolver.configuration.cache_failures
       url
     rescue Exception => e

--- a/url_resolver.gemspec
+++ b/url_resolver.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'url_resolver'
-  s.version     = '0.2.2'
+  s.version     = '0.2.3'
   s.date        = '2016-09-10'
   s.summary     = "Url Resolver!"
   s.description = "Simple gem to follow redirects to resolve the destination of a URL. Caches results sometimes."
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
     'http://www.github.com/amirmanji/url_resolver'
   s.license       = 'MIT'
   s.add_runtime_dependency "rest-client", '~> 2.0'
-  s.add_development_dependency "rspec", [ "2.14.7" ]
+  s.add_development_dependency "rspec", ['3.6.0']
 end

--- a/url_resolver.gemspec
+++ b/url_resolver.gemspec
@@ -10,6 +10,6 @@ Gem::Specification.new do |s|
   s.homepage    =
     'http://www.github.com/amirmanji/url_resolver'
   s.license       = 'MIT'
-  s.add_runtime_dependency "rest-client", '~> 1.8'
+  s.add_runtime_dependency "rest-client", '~> 2.0'
   s.add_development_dependency "rspec", [ "2.14.7" ]
 end

--- a/url_resolver.gemspec
+++ b/url_resolver.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'url_resolver'
-  s.version     = '0.2.0'
-  s.date        = '2016-05-18'
+  s.version     = '0.2.1'
+  s.date        = '2016-09-10'
   s.summary     = "Url Resolver!"
   s.description = "Simple gem to follow redirects to resolve the destination of a URL. Caches results sometimes."
   s.authors     = ["Amir Manji"]

--- a/url_resolver.gemspec
+++ b/url_resolver.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'url_resolver'
-  s.version     = '0.2.1'
+  s.version     = '0.2.2'
   s.date        = '2016-09-10'
   s.summary     = "Url Resolver!"
   s.description = "Simple gem to follow redirects to resolve the destination of a URL. Caches results sometimes."


### PR DESCRIPTION
url_resolver is great! I wanted to quickly resolve a bunch of URLs but some connect slowly and I wanted to discard them. I added a feature to support an open timeout so a caller can set a low or high timeout if desired
